### PR TITLE
add AbandonProcessGroup for macos

### DIFF
--- a/autostart_darwin.go
+++ b/autostart_darwin.go
@@ -20,6 +20,8 @@ const jobTemplate = `<?xml version="1.0" encoding="UTF-8"?>
       </array>
     <key>RunAtLoad</key>
     <true/>
+    <key>AbandonProcessGroup</key>
+    <true/>
   </dict>
 </plist>`
 


### PR DESCRIPTION
@emersion

For macOS, when the launching process starts a child process (such as opening up a new application) and then quits, `launchd` will terminate all child processes too.

This option keeps child processes running.

See:
https://cetre.co.uk/blog/moving-from-cron-to-launchd-on-mac-os-x-server/
